### PR TITLE
Fix bug with empty posts on results page

### DIFF
--- a/class-swiftype-plugin.php
+++ b/class-swiftype-plugin.php
@@ -311,6 +311,7 @@
 
 			$ordered_posts = array();
 			foreach( $this->post_ids as $pid ) {
+				if ( ! isset( $lookup_table[ $pid ] ) ) continue;
 				$ordered_posts[] = $lookup_table[ $pid ];
 			}
 


### PR DESCRIPTION
Found a bug today on our website with empty posts displaied on search
results page.

Chances are that not all posts available from swiftype api are currently
on this page, so we end with many `NULL` objects in `$ordered_posts`,
because for $lookup_table contains 2 posts with ids 10 and 12,
`$post_ids` recieved from swiftype api are: 10..20, first two items
go into `$ordered_posts` but when loop continues to iterate through
13..20 we add another 8 NULL objects into `$ordered_posts` because
`$lookup_table` does not have anything at those indeces.
