### PR TITLE
Added a filter for $query_string, to change query sent to swiftype.

### DIFF
--- a/class-swiftype-plugin.php
+++ b/class-swiftype-plugin.php
@@ -153,7 +153,7 @@
 				return;
 			}
 			if( is_search() && ! is_admin() && $this->engine_slug && strlen( $this->engine_slug ) > 0) {
-				$query_string = stripslashes( get_search_query( false ) );
+				$query_string = apply_filters( 'swiftype_search_query_string', stripslashes( get_search_query( false ) ) );
 				$page = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
 
 				$params = array( 'page' => $page );


### PR DESCRIPTION
Added in the `swiftype_search_query_string` filter, for users to manipulate the query before sending it to swiftype. This is similar to how `swiftype_search_params` works.

For Example:

```
function swiftype_search_query_filter( $query ) {
    list($keywords, $tags) = parse_tags($query);
    return $keywords;
}
add_filter( 'swiftype_search_query_string', 'swiftype_search_query_filter', 8, 1 );

```
