### PR TITLE
changed the priority of pre_get_posts

### DIFF
--- a/class-swiftype-plugin.php
+++ b/class-swiftype-plugin.php
@@ -44,7 +44,7 @@
 
 			if ( ! is_admin() ) {
 				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_swiftype_assets' ) );
-				add_action( 'pre_get_posts', array( $this, 'get_posts_from_swiftype' ) );
+				add_action( 'pre_get_posts', array( $this, 'get_posts_from_swiftype' ), 11 );
 				add_filter( 'posts_search', array( $this, 'clear_sql_search_clause' ) );
 				add_filter( 'post_limits', array( $this, 'set_sql_limit' ) );
 				add_filter( 'the_posts', array( $this, 'get_search_result_posts' ) );


### PR DESCRIPTION
Changed the priority of pre_get_posts from the default 10 to 11. Fixes woocommerce integrations.

I debated adding this to the readme vs changing from the default value. I settled on changing the value because I think we want to have a higher priority in most cases.