### PR TITLE
Make defaultOnComplete function overridable

### DIFF
--- a/assets/swiftype_config.js
+++ b/assets/swiftype_config.js
@@ -6,6 +6,10 @@
         var title = item['highlight']['title'] || Swiftype.htmlEscape(item['title']);
         return '<p class="title">' + title + '</p>';
     };
+   
+    var defaultOnComplete =  function(dataItem, prefix) {
+     Swiftype.pingAutoSelection(Swiftype.key, dataItem['id'], prefix, function() { window.location = dataItem['url']; });
+   };
 
     function readSwiftypeConfigFor(option) {
       if ((typeof window.swiftypeConfig === 'undefined') || (typeof window.swiftypeConfig[option] === 'undefined') || window.swiftypeConfig[option] === null) {
@@ -46,9 +50,7 @@
     };
 
     var swiftypeOptions = {
-      onComplete: function(dataItem, prefix) {
-        Swiftype.pingAutoSelection(Swiftype.key, dataItem['id'], prefix, function() { window.location = dataItem['url']; });
-      },
+      onComplete: (window.swiftypeConfig && window.swiftypeConfig["onComplete"]) || defaultOnComplete,
       documentTypes: ['posts'],
       engineKey: Swiftype.key,
       filters: SwiftypeConfigManager.getFilters(),


### PR DESCRIPTION
Unfortunately the onComplete function is hard coded in the options.

We have a situation where we want autocomplete results to open in a new page.

So, in the same spirit as defaultRenderFunction, I've extracted the hard coded function to a default, and added the ability to define a custom onComplete function in your swiftypeOptions.
