### PR TITLE
Use `wp_strip_all_tags()` instead of `strip_tags()`.

### DIFF
--- a/class-swiftype-plugin.php
+++ b/class-swiftype-plugin.php
@@ -657,9 +657,9 @@
 			$document['fields'][] = array( 'name' => 'object_type', 'type' => 'enum', 'value' => $post->post_type );
 			$document['fields'][] = array( 'name' => 'url', 'type' => 'enum', 'value' => get_permalink( $post->ID ) );
 			$document['fields'][] = array( 'name' => 'timestamp', 'type' => 'date', 'value' => $post->post_date_gmt );
-			$document['fields'][] = array( 'name' => 'title', 'type' => 'string', 'value' => html_entity_decode( strip_tags( $post->post_title ), ENT_QUOTES, "UTF-8" ) );
-			$document['fields'][] = array( 'name' => 'body', 'type' => 'text', 'value' => html_entity_decode( strip_tags( $this->strip_shortcodes_retain_contents( $post->post_content ) ), ENT_QUOTES, "UTF-8" ) );
-			$document['fields'][] = array( 'name' => 'excerpt', 'type' => 'text', 'value' => html_entity_decode( strip_tags( $post->post_excerpt ), ENT_QUOTES, "UTF-8" ) );
+			$document['fields'][] = array( 'name' => 'title', 'type' => 'string', 'value' => html_entity_decode( wp_strip_all_tags( $post->post_title ), ENT_QUOTES, "UTF-8" ) );
+			$document['fields'][] = array( 'name' => 'body', 'type' => 'text', 'value' => html_entity_decode( wp_strip_all_tags( $this->strip_shortcodes_retain_contents( $post->post_content ) ), ENT_QUOTES, "UTF-8" ) );
+			$document['fields'][] = array( 'name' => 'excerpt', 'type' => 'text', 'value' => html_entity_decode( wp_strip_all_tags( $post->post_excerpt ), ENT_QUOTES, "UTF-8" ) );
 			$document['fields'][] = array( 'name' => 'author', 'type' => 'string', 'value' => array( $nickname, $name ) );
 			$document['fields'][] = array( 'name' => 'tags', 'type' => 'string', 'value' => $tag_strings );
 			$document['fields'][] = array( 'name' => 'category', 'type' => 'enum', 'value' => wp_get_post_categories( $post->ID ) );

--- a/class-swiftype-widget.php
+++ b/class-swiftype-widget.php
@@ -68,7 +68,7 @@ class Swiftype_Search_Widget extends WP_Widget {
 	function update( $new_instance, $old_instance ) {
 		$instance = $old_instance;
 		$new_instance = wp_parse_args( (array) $new_instance, array( 'title' => '', 'category' => 0 ) );
-		$instance['title'] = strip_tags( $new_instance['title'] );
+		$instance['title'] = wp_strip_all_tags( $new_instance['title'] );
 		$instance['category'] = intval( $new_instance['category'] );
 		return $instance;
 	}


### PR DESCRIPTION
`strip_tags()` does not remove the contents of `<script>` and `<style>` tags. `wp_strip_all_tags()` should therefore be used, and is required per WordPress VIP Coding Standards.