### PR TITLE
Remove unused variable `$total_posts`.

### DIFF
--- a/class-swiftype-plugin.php
+++ b/class-swiftype-plugin.php
@@ -497,7 +497,6 @@
 
 			$offset = isset( $_POST['offset'] ) ? intval( $_POST['offset'] ) : 0;
 			$batch_size = isset( $_POST['batch_size'] ) ? intval( $_POST['batch_size'] ) : 10;
-			$total_posts = 0;
 
 			try {
 				$total_posts = $this->delete_batch_of_trashed_posts( $offset, $batch_size );


### PR DESCRIPTION
The code flow ensures that the initially assigned value of this variable is never used, and therefore isn't needed.