### PR TITLE
Use `wp_json_encode()` instead of `json_encode()`.

### DIFF
--- a/class-swiftype-client.php
+++ b/class-swiftype-client.php
@@ -263,7 +263,7 @@ public function delete_documents( $engine_id, $document_type_id, $document_ids )
 			$args['body'] = array();
 		} else if( $method == 'POST' ) {
 			$args['method'] = $method;
-			$args['body'] = json_encode( $params );
+			$args['body'] = wp_json_encode( $params );
 		}
 
 		$response = wp_remote_request( $url, $args );

--- a/class-swiftype-plugin.php
+++ b/class-swiftype-plugin.php
@@ -398,7 +398,7 @@
 			$this->num_indexed_documents = $document_type['document_count'];
 			update_option( 'swiftype_num_indexed_documents', $this->num_indexed_documents );
 			header( 'Content-Type: application/json' );
-			print( json_encode( array( 'num_indexed_documents' => $this->num_indexed_documents ) ) );
+			print( wp_json_encode( array( 'num_indexed_documents' => $this->num_indexed_documents ) ) );
 			die();
 		}
 
@@ -418,7 +418,7 @@
 				list( $num_written, $total_posts ) = $this->index_batch_of_posts( $offset, $batch_size );
 
 				header( 'Content-Type: application/json' );
-				print( json_encode( array( 'num_written' => $num_written, 'total' => $total_posts ) ) );
+				print( wp_json_encode( array( 'num_written' => $num_written, 'total' => $total_posts ) ) );
 				die();
 
 			} catch ( SwiftypeError $e ) {
@@ -509,7 +509,7 @@
 			}
 
 			header( "Content-Type: application/json" );
-			print( json_encode( array( 'total' => $total_posts ) ) );
+			print( wp_json_encode( array( 'total' => $total_posts ) ) );
 			die();
 		}
 


### PR DESCRIPTION
`wp_json_encode()` is just a wrapper for the PHP function, but it contains sanity checks that make it more useful among a variety of server configurations.