### PR TITLE
Removed outdated youtube video

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -18,9 +18,6 @@ The base ranking algorithm is based on industry best-practices for search and pr
 
 Do you have a mobile app displaying content from your WordPress site? Swiftype’s [mobile SDKs](https://swiftype.com/mobile) make it simple to add powerful search to your mobile apps.  Combine our WordPress plugin with our mobile SDKs to create the same search experience on your site and in your app.
 
-
-[youtube="http://www.youtube.com/watch?v=rukXYKEpvS4"]
-
 ## Features
 
 * Search runs on our powerful servers - it doesn't bog down your site, even if you have **hundreds of thousands of posts**.


### PR DESCRIPTION
The embedded video included is severely outdated. I removed the video until an appropriate, updated video can be provided.

> In this video around 53s it shows that there is an option “Advanced settings” to chose an existing engine instead of creating a new one: https://www.youtube.com/watch?time_continue=53&v=rukXYKEpvS4

> this “Advanced” option doesn’t exist while installing the Wordpress plugin.