### PR TITLE
Fix error not being shown in error box

### DIFF
--- a/templates/admin/controls/synchronize.php
+++ b/templates/admin/controls/synchronize.php
@@ -115,12 +115,13 @@ foreach( $allowedPostTypes as $type ) {
     };
 
     function onError(jqXHR, textStatus, errorThrown) {
+        var errorMsg;
         try {
             errorMsg = JSON.parse(jqXHR.responseText).message;
         } catch (e) {
             errorMsg = jqXHR.responseText;
-            showErrors(errorMsg);
         }
+        showErrors(errorMsg);
     };
 
     function onIndexBatchSuccess(response) {


### PR DESCRIPTION
Closes #58.

This PR adds missing `showError` call in `try` block.