### PR TITLE
Fix CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,7 @@ job-references:
     command: |
       sudo apt-get update && sudo apt-get install subversion
       sudo -E docker-php-ext-install mysqli
-      sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
-      sudo apt-get update && sudo apt-get install mysql-client-5.7
+      sudo apt-get update && sudo apt-get install default-mysql-client
 
   php_job: &php_job
     environment:

--- a/scripts/install-wp-tests.sh
+++ b/scripts/install-wp-tests.sh
@@ -107,8 +107,8 @@ install_test_suite() {
     if [ ! -d $WP_TESTS_DIR ]; then
         # set up testing suite
         mkdir -p $WP_TESTS_DIR
-        svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
-        svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+        svn co --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+        svn co --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
     fi
 
     if [ ! -f wp-tests-config.php ]; then


### PR DESCRIPTION
Following suggestions at https://discuss.circleci.com/t/build-failing-everytime-docker-wordpress-mysql-php-the-following-packages-have-unmet-dependencies/35861/2 to fix the dependencies installation issue.

Following suggestions at https://meta.trac.wordpress.org/ticket/4869#comment:1 to fix the flaky tests. `svn` is rate limited in this context; adding `--ignore-externals` reduces traffic. Also, I removed `--quiet` so that, in case this fails again, we may see more useful output.