### PR TITLE
Absolute paths to required files

### DIFF
--- a/swiftype.php
+++ b/swiftype.php
@@ -11,9 +11,9 @@ Author URI: http://swiftype.com
 
 define('SWIFTYPE_VERSION', '2.0.4');
 
-require_once('vendor/autoload.php');
+require_once __DIR__ . '/vendor/autoload.php';
 
-require_once 'swiftype-theme-functions.php';
+require_once __DIR__ . '/swiftype-theme-functions.php';
 
 if (defined('WP_CLI') && WP_CLI) {
     WP_CLI::add_command('swiftype', 'Swiftype\SiteSearch\Wordpress\Cli\Command');


### PR DESCRIPTION
When using the plugin on a project that uses Composer, the relative path in `require_once('vendor/autoload.php')` could cause PHP to include `vendor/autoload.php` from the project root instead of the plugin directory, resulting in fatal errors when classes cannot be found. An absolute path in the `require_once` avoids this issue.