### PR TITLE
Do not index attachment by default anymore.

### DIFF
--- a/Config/Config.php
+++ b/Config/Config.php
@@ -144,6 +144,6 @@ class Config
             );
         }
 
-        return $allowedPostTypes;
+        return \apply_filters('swiftype_allowed_post_types', $allowedPostTypes);
     }
 }

--- a/Document/Indexer.php
+++ b/Document/Indexer.php
@@ -33,9 +33,11 @@ class Indexer extends AbstractSwiftypeComponent
     }
 
     /**
+     * Filter out forbiden post types fron indexing.
      *
+     * @param string[] $allowedPostTypes
      *
-     * @return void
+     * @return string[]
      */
     public function filterAllowedPostType($allowedPostTypes)
     {

--- a/Document/Indexer.php
+++ b/Document/Indexer.php
@@ -17,13 +17,29 @@ class Indexer extends AbstractSwiftypeComponent
     private $documentMapper;
 
     /**
+     * @var string[]
+     */
+    private static $FORBIDDEN_POST_TYPES = ['attachment'];
+
+    /**
      * Constructor.
      */
     public function __construct()
     {
         parent::__construct();
         $this->documentMapper = new Mapper();
+        \add_filter('swiftype_allowed_post_types', [$this, 'filterAllowedPostType']);
         \add_action('swiftype_engine_loaded', [$this, 'installHooks']);
+    }
+
+    /**
+     *
+     *
+     * @return void
+     */
+    public function filterAllowedPostType($allowedPostTypes)
+    {
+        return \array_diff($allowedPostTypes, self::$FORBIDDEN_POST_TYPES);
     }
 
     /**
@@ -44,8 +60,8 @@ class Indexer extends AbstractSwiftypeComponent
           \add_action('trashed_post', [$this, 'handleTrashedPost']);
 
 
-          add_action('swiftype_batch_post_index', [$this, 'handlePostBatchIndex']);
-          add_action('swiftype_batch_post_delete', [$this, 'handlePostBatchDelete']);
+          \add_action('swiftype_batch_post_index', [$this, 'handlePostBatchIndex']);
+          \add_action('swiftype_batch_post_delete', [$this, 'handlePostBatchDelete']);
         }
     }
 


### PR DESCRIPTION
- Add the ability to customize allowed post types (new filter `swiftype_allowed_post_types`)
- Add a default filter that filters out `attachment` during indexing